### PR TITLE
core(bundling): Added browserify-based bundle script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 # DS_Store
 .DS_Store
 dist
+ng-forward.js

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "gulp test",
     "prepublish": "gulp test",
-    "bundle": "browserify -t [ babelify --stage 0 ] ./src/index.js --standalone ng-forward --ignore reflect-metadata | derequire > ./ng-forward.js"
+    "bundle": "browserify -t [ babelify --stage 0 ] ./src/index.js --standalone ng-forward -i reflect-metadata -x rx-lite | derequire > ./ng-forward.js"
   },
   "keywords": [
     "angular",
@@ -56,7 +56,8 @@
     "mocha": "^2.2.1",
     "phantomjs": "^1.9.17",
     "sinon": "^1.14.1",
-    "sinon-chai": "^2.7.0"
+    "sinon-chai": "^2.7.0",
+    "uglifyjs": "^2.4.10"
   },
   "dependencies": {
     "metawriter": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "test": "gulp test",
-    "prepublish": "gulp test"
+    "prepublish": "gulp test",
+    "bundle": "browserify -t [ babelify --stage 0 ] ./src/index.js --standalone ng-forward --ignore reflect-metadata | derequire > ./ng-forward.js"
   },
   "keywords": [
     "angular",
@@ -35,8 +36,10 @@
     "angular-mocks": "^1.4.3",
     "babel": "^5.0.8",
     "babel-eslint": "^3.1.23",
-    "babelify": "^6.1.3",
+    "babelify": "^6.3.0",
+    "browserify": "^11.2.0",
     "chai": "^2.2.0",
+    "derequire": "^2.0.2",
     "eslint": "^0.24.0",
     "gulp": "^3.8.11",
     "gulp-babel": "^5.0.0",
@@ -56,8 +59,7 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "extend": "^3.0.0",
     "metawriter": "^1.0.0",
-    "rx": "^2.5.3"
+    "rx-lite": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "gulp test",
     "prepublish": "gulp test",
-    "bundle": "browserify -t [ babelify --stage 0 ] ./src/index.js --standalone ng-forward -i reflect-metadata | derequire > ./ng-forward.js"
+    "bundle": "browserify -t [ babelify --stage 0 ] ./src/index.js --standalone ng-forward -i reflect-metadata | derequire | uglifyjs > ./ng-forward.js"
   },
   "keywords": [
     "angular",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "gulp test",
     "prepublish": "gulp test",
-    "bundle": "browserify -t [ babelify --stage 0 ] ./src/index.js --standalone ng-forward -i reflect-metadata -x rx-lite | derequire > ./ng-forward.js"
+    "bundle": "browserify -t [ babelify --stage 0 ] ./src/index.js --standalone ng-forward -i reflect-metadata | derequire > ./ng-forward.js"
   },
   "keywords": [
     "angular",
@@ -60,7 +60,7 @@
     "uglifyjs": "^2.4.10"
   },
   "dependencies": {
-    "metawriter": "^1.0.0",
-    "rx-lite": "^4.0.1"
+    "@reactivex/rxjs": "^5.0.0-alpha.3",
+    "metawriter": "^1.0.0"
   }
 }

--- a/src/util/directive-controller.js
+++ b/src/util/directive-controller.js
@@ -10,8 +10,6 @@
 import {propertiesBuilder} from './properties-builder';
 // Also need the eventsBuilder for creating event emittors
 import eventsBuilder from './events-builder';
-// Finally extend for extending the instance of the controller
-import extend from 'extend';
 
 // ## Factory
 // Needs the injection array, the controller class, and the directive definition
@@ -27,7 +25,7 @@ export default function createDirectiveController(caller, injects, controller, d
   // Remember, angular has alrady set those bindings on the prototype of the calling
   // function. Now we need to extend them onto our instance. important
   // to extend after building the properties that way we fire the setters
-  extend(instance, caller);
+  Object.assign(instance, caller);
 
   // Finally, invoke the constructor using the injection array and the captured
   // locals

--- a/src/util/event-emitter.js
+++ b/src/util/event-emitter.js
@@ -1,14 +1,13 @@
 /* global setTimeout */
 // # EventEmitter class
 // Simple re-implementation of Angular 2's [EventEmitter](https://github.com/angular/angular/blob/master/modules/angular2/src/facade/async.ts#L97)
-import {Subject, Scheduler} from 'rx';
+import {Subject} from 'rx';
 
 export class EventEmitter{
   _subject = new Subject();
-  _immediateScheduler = Scheduler.immediate;
 
   observer(generator){
-    return this._subject.observeOn(this._immediateScheduler)
+    return this._subject
       .subscribe(
         value => setTimeout(() => generator.next(value)),
         error => generator.throw ? generator.throw(error) : null,

--- a/src/util/event-emitter.js
+++ b/src/util/event-emitter.js
@@ -1,7 +1,7 @@
 /* global setTimeout */
 // # EventEmitter class
 // Simple re-implementation of Angular 2's [EventEmitter](https://github.com/angular/angular/blob/master/modules/angular2/src/facade/async.ts#L97)
-import {Subject} from 'rx';
+import {Subject} from 'rx-lite';
 
 export class EventEmitter{
   _subject = new Subject();

--- a/src/util/event-emitter.js
+++ b/src/util/event-emitter.js
@@ -1,14 +1,13 @@
 /* global setTimeout */
 // # EventEmitter class
-// Simple re-implementation of Angular 2's [EventEmitter](https://github.com/angular/angular/blob/master/modules/angular2/src/facade/async.ts#L97)
-import {Subject} from 'rx-lite';
+// Simple re-implementation of Angular 2's [EventEmitter](https://github.com/angular/angular/blob/master/modules/angular2/src/core/facade/async.ts#L137)
+import Subject from '@reactivex/rxjs/dist/cjs/Subject';
 
 export class EventEmitter{
   _subject = new Subject();
 
   observer(generator){
-    return this._subject
-      .subscribe(
+    return this._subject.subscribe(
         value => setTimeout(() => generator.next(value)),
         error => generator.throw ? generator.throw(error) : null,
         () => generator.return ? generator.return() : null
@@ -20,14 +19,14 @@ export class EventEmitter{
   }
 
   next(value){
-    this._subject.onNext(value);
+    this._subject.next(value);
   }
 
   throw(error){
-    this._subject.onError(error);
+    this._subject.error(error);
   }
 
   return(){
-    this._subject.onCompleted();
+    this._subject.complete();
   }
 }


### PR DESCRIPTION
Adds a bundle script for creating a standalone version of ng-forward. To create a bundle, run `npm run bundle`. It will generate a file called `ng-forward.js` in the root directory. To keep the filesize small, the Reflect.metadata shim is not included.