### PR TITLE
fix issue with sourcemaps

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -54,7 +54,7 @@ function buildCJSDist(){
 	let transpile = gulp.src('./dist/es6/**/*.js')
 		.pipe(sourcemaps.init({ loadMaps: true }))
 		.pipe(babel({ modules: 'common', stage: 0 }))
-		.pipe(sourcemaps.write())
+		.pipe(sourcemaps.write('.'))
 		.pipe(gulp.dest('./dist/cjs'));
 
 	let move = gulp.src('./dist/es6/**/*.d.ts')


### PR DESCRIPTION
For some reason browserify and tsify did not work well with inline source maps.
I made it external for the cjs folder.

The fix is just a little '.' :-)
This fixes #40 for me.
