### PR TITLE
feat(controllerAs): Set default controllerAs value to 'ctrl'.

### DIFF
--- a/API.md
+++ b/API.md
@@ -170,7 +170,7 @@ import { Component } from 'ng-forward';
 
 @Component({ 
     selector: 'app', 
-    template: `Hello {{app.place}}!`,
+    template: `Hello {{ctrl.place}}!`,
     providers: [...providers],
     directives: [...directives]
     pipes: [...pipes]
@@ -192,7 +192,7 @@ class App {
 - **`pipes`**  **[Array&lt;[IProvidable](https://github.com/ngUpgraders/ng-forward/blob/master/API.md#iprovidable)&gt;]**  Any [pipes](https://github.com/ngUpgraders/ng-forward/blob/master/API.md#pipe) that this component or any of it's children depends on.
 - **`inputs`**  **[Array&lt;string&gt;]**  An array of strings naming what class properties you want to expose in `bindToController` (or `scope` if angular 1.3). For example, `inputs: ['foo']` will connect the class property `foo` to the input `foo`. You can also rename the input, for example `inputs: ['foo:theFoo']` will connect the class property `foo` to the input `the-foo`.
 - **`outputs`**  **[Array&lt;string&gt;]**  An array of strings naming what class properties you want to expose as outputs. For example, `outputs: ['fooChange']` will notify the app that this component can fire a `'fooChange'` event. If there is a class property `fooChange` that is an `EventEmitter` it can trigger this event via `this.fooChange.next()`. Otherwise the event can also be triggered with a regular DOM event of name `'fooChange'`. You can also rename the output, for example `inputs: ['fooChange:theFooChange']` will notify of a 'theFooChange' event, but will still look for a `fooChange` property on the class.
-- **`controllerAs`**  **[string=selector camel-cased]**  The controller name used in the template.
+- **`controllerAs`**  **[string='ctrl']**  The controller name used in the template. By default uses 'ctrl'. We wanted to use something consistent across all components to make migration to Angular 2 easier later. When migrating you'll only need to do a simple find and replace of all 'ctrl.' and remove them. If you want the controllerAs name to match the selector (camel-cased) then set controllerAs to '$auto'.
 
 ###### Inputs and Outputs
 
@@ -206,8 +206,8 @@ If you had a component `MenuDropdown` like so:
 @Component({ 
     selector: 'menu-dropdown', 
     template: `
-    <label>{{menuDropdown.name}}</label>
-    <a ng-repeat="option in menDropdown.options" ng-href="{{option.action}}">{{option.name}}</a>
+    <label>{{ctrl.name}}</label>
+    <a ng-repeat="option in ctrl.options" ng-href="{{option.action}}">{{option.name}}</a>
     `,
     inputs: ['options'],
     outputs: ['optionSelect']
@@ -225,7 +225,7 @@ Then I could use that component in another component's template like so, passing
 @Component({
     selector: 'main-menu',
     template: `
-    <div ng-repeat="menu in mainMenu.menus">
+    <div ng-repeat="menu in ctrl.menus">
         <menu [options]="menu.options" (option-select)="menu.optionSelected($event)"></menu>
     </div>
     `
@@ -290,7 +290,7 @@ At [bootstrap](https://github.com/ngUpgraders/ng-forward/blob/master/API.md#boot
 - `template` is set via the @Component config template property (`templateUrl` can also be used)
 - `controller` is set to the class instance, but it not instantiated until after the link phase so that child directives are available in the DOM. `$scope`, `$element`, `$attrs`, and `$transclude` are injectable as locals.
 - `restrict` is set to 'E' since components must use tag-based selectors.
-- `controllerAs` is set to a camel-cased version of the selector but can be overridden if you prefer 'vm' or something else.
+- `controllerAs` is set to 'ctrl' but can be overridden if you prefer 'vm' or something else. Or you can set it to '$auto' which will set it to a camel-cased version of the selector.
 - `scope` and `bindToController`:
     - If angular 1.3, inputs are set on an isolated `scope` and `bindToController` to `true`.
     - If angular 1.4+, `scope` is set to an isolate scope with `{}` and inputs are set on `bindToController` object.
@@ -332,7 +332,6 @@ At [bootstrap](https://github.com/ngUpgraders/ng-forward/blob/master/API.md#boot
 - `template` is not set.
 - `controller` is set to the class instance, but it not instantiated until after the link phase so that child directives are available in the DOM. `$scope`, `$element`, `$attrs`, and `$transclude` are injectable as locals.
 - `restrict` is set to 'A' since directives must use attribute-based selectors.
-- `controllerAs` is set to a camel-cased version of the selector but can be overridden if you prefer 'vm' or something else.
 - `scope` is not set and so is not isolated.
 - `link` and `compile` are not set and are not able to be set.
 
@@ -405,7 +404,7 @@ Ng-Forward adds the following extensions to the JQLite / JQuery object returned 
 
 #### nativeElement
 
-**read-only** The native DOM element inside the jq wrapper. 
+**read-only** The native DOM element inside the jq wrapper.
 
 #### componentInstance
 
@@ -610,7 +609,7 @@ import uiRouter from 'ui-router';
 
 @Component({
     selector: 'childA',
-    template: '{{ childA.text }}' // will be 'A resolved!'
+    template: '{{ ctrl.text }}' // will be 'A resolved!'
 })
 @Inject('resolveA')
 class ChildA {
@@ -652,7 +651,7 @@ import uiRouter from 'ui-router';
 
 @Component({
     selector: 'childA',
-    template: '{{ childA.text }}' // will be 'A resolved!'
+    template: '{{ ctrl.text }}' // will be 'A resolved!'
 })
 @Inject('resolveA')
 class ChildA {

--- a/Walkthrough.md
+++ b/Walkthrough.md
@@ -86,25 +86,25 @@ import { Component, Inject, Input, Output } from 'ng-forward';
 	directives: [Nested],
 	template: `
 		<h2>Inner app</h2>
-		<p>ES7 async resolved value: {{ innerApp.num || 'resolving...' }}</p>
+		<p>ES7 async resolved value: {{ ctrl.num || 'resolving...' }}</p>
 		<nested></nested>
 
 		<h4>Event</h4>
-		<button (click)="innerApp.triggerEventNormally()">
+		<button (click)="ctrl.triggerEventNormally()">
 			Trigger DOM Event
 		</button>
-		<button (click)="innerApp.triggerEventViaEventEmitter()">
+		<button (click)="ctrl.triggerEventViaEventEmitter()">
 			Trigger Emitted Event
 		</button>
 
 		<h4>One Way String from Parent (read-only)</h4>
-		<p>{{innerApp.msg3}}</p>
+		<p>{{ctrl.msg3}}</p>
 
 		<h4>One Way Binding from Parent (read-only)</h4>
-		<input ng-model="innerApp.message1"/>
+		<input ng-model="ctrl.message1"/>
 
 		<h4>Two Way Binding to/from Parent (read/write)</h4>
-		<input ng-model="innerApp.message2"/>
+		<input ng-model="ctrl.message2"/>
 	`
 })
 @Inject(TestService, '$element')
@@ -160,10 +160,10 @@ Let's take a look at the template for this component:
 
 ```js
 		<h4>Event</h4>
-		<button (click)="innerApp.triggerEventNormally()">
+		<button (click)="ctrl.triggerEventNormally()">
 			Trigger DOM Event
 		</button>
-		<button (click)="innerApp.triggerEventViaEventEmitter()">
+		<button (click)="ctrl.triggerEventViaEventEmitter()">
 			Trigger Emitted Event
 		</button>
 ```
@@ -186,13 +186,13 @@ Here's a part of the template that makes a simple reference to properties passed
 
 ```
 <h4>One Way String from Parent (read-only)</h4>
-<p>{{innerApp.msg3}}</p>
+<p>{{ctrl.msg3}}</p>
 
 <h4>One Way Binding from Parent (read-only)</h4>
-<input ng-model="innerApp.message1"/>
+<input ng-model="ctrl.message1"/>
 
 <h4>Two Way Binding to/from Parent (read/write)</h4>
-<input ng-model="innerApp.message2"/>
+<input ng-model="ctrl.message2"/>
 ```
 
 Note the references to one or two way binding. In Angular 2, properties by default are one way bound. We use some trickery under the hood in ng-forward to simulate one way binding in Angular 1.x. When we look at the parent component we'll show you how you can override one way binding and make a two way bound data property.
@@ -247,18 +247,18 @@ Let's look at the final building block of the ng-forward app, the top level comp
 	template: `
 		<h1>App</h1>
 		<nested></nested>
-		<p>Trigger count: {{ app.triggers }}</p>
+		<p>Trigger count: {{ ctrl.triggers }}</p>
 
 		<h4>One Way Binding to Child:</h4>
-		<input ng-model="app.message1"/>
+		<input ng-model="ctrl.message1"/>
 
 		<h4>Two Way Binding to/from Child:</h4>
-		<input ng-model="app.message2"/>
+		<input ng-model="ctrl.message2"/>
 
 		<hr/>
 
-		<inner-app (event1)="app.onIncrement()" (event2)="app.onIncrement()"
-		           [message1]="app.message1" [(message2)]="app.message2" message3="Hey, inner app... nothin'">
+		<inner-app (event1)="ctrl.onIncrement()" (event2)="ctrl.onIncrement()"
+		           [message1]="ctrl.message1" [(message2)]="ctrl.message2" message3="Hey, inner app... nothin'">
 		</inner-app>
 	`
 })
@@ -287,7 +287,7 @@ There are a few extra elements we need to look at here that ng-forward uses to b
 
 Providers are used to specify what services are injectable in our app. They're the closest thing ng-forward has to angular.module from 1.x. If you need to use a legacy module, you'll pass it here as a string. Otherwise, just pass the services your component will need.
 
-*Angular 2 difference: You might be wondering why you'd pass TestService as a provider here, and then still have to inject it in the innerApp component. In Angular 2, providers is actually a way to specify what services are available inside the component in a hierarchical fashion. In ng-forward, any services you pass to providers on any component will be available to inject on any other component, because the Angular 1.x injector doesn't support this hierarchy. You should still try to limit cross usage to prevent pain during upgrade.*
+*Angular 2 difference: You might be wondering why you'd pass TestService as a provider here, and then still have to inject it in the ctrl component. In Angular 2, providers is actually a way to specify what services are available inside the component in a hierarchical fashion. In ng-forward, any services you pass to providers on any component will be available to inject on any other component, because the Angular 1.x injector doesn't support this hierarchy. You should still try to limit cross usage to prevent pain during upgrade.*
 
 *Tip: Use strings in the `@Inject` decorator to specify legacy services, e.g. '$q'. Use strings in `providers` or `directives` to specify legacy modules, e.g. 'ui.router'*
 
@@ -303,15 +303,15 @@ Let's look at how we call the InnerApp component
 
 ```js
 		<h4>One Way Binding to Child:</h4>
-		<input ng-model="app.message1"/>
+		<input ng-model="ctrl.message1"/>
 
 		<h4>Two Way Binding to/from Child:</h4>
-		<input ng-model="app.message2"/>
+		<input ng-model="ctrl.message2"/>
 
 		<hr/>
 
-		<inner-app (event1)="app.onIncrement()" (event2)="app.onIncrement()"
-		           [message1]="app.message1" [(message2)]="app.message2" message3="Hey, inner app... nothin'">
+		<inner-app (event1)="ctrl.onIncrement()" (event2)="ctrl.onIncrement()"
+		           [message1]="ctrl.message1" [(message2)]="ctrl.message2" message3="Hey, inner app... nothin'">
 		</inner-app>
 ```
 
@@ -357,25 +357,25 @@ class Nested{ }
 	directives: [Nested],
 	template: `
 		<h2>Inner app</h2>
-		<p>ES7 async resolved value: {{ innerApp.num || 'resolving...' }}</p>
+		<p>ES7 async resolved value: {{ ctrl.num || 'resolving...' }}</p>
 		<nested></nested>
 
 		<h4>Event</h4>
-		<button (click)="innerApp.triggerEventNormally()">
+		<button (click)="ctrl.triggerEventNormally()">
 			Trigger DOM Event
 		</button>
-		<button (click)="innerApp.triggerEventViaEventEmitter()">
+		<button (click)="ctrl.triggerEventViaEventEmitter()">
 			Trigger Emitted Event
 		</button>
 
 		<h4>One Way String from Parent (read-only)</h4>
-		<p>{{innerApp.msg3}}</p>
+		<p>{{ctrl.msg3}}</p>
 
 		<h4>One Way Binding from Parent (read-only)</h4>
-		<input ng-model="innerApp.message1"/>
+		<input ng-model="ctrl.message1"/>
 
 		<h4>Two Way Binding to/from Parent (read/write)</h4>
-		<input ng-model="innerApp.message2"/>
+		<input ng-model="ctrl.message2"/>
 	`
 })
 @Inject(TestService, '$element')
@@ -415,17 +415,17 @@ class InnerApp{
 	template: `
 		<h1>App</h1>
 		<nested></nested>
-		<p>Trigger count: {{ app.triggers }}</p>
+		<p>Trigger count: {{ ctrl.triggers }}</p>
 
 		<h4>One Way Binding to Child:</h4>
-		<input ng-model="app.message1"/>
+		<input ng-model="ctrl.message1"/>
 
 		<h4>Two Way Binding to/from Child:</h4>
-		<input ng-model="app.message2"/>
+		<input ng-model="ctrl.message2"/>
 
 		<hr/>
-		<inner-app (event1)="app.onIncrement()" (event2)="app.onIncrement()"
-		           [message1]="app.message1" [(message2)]="app.message2" message3="Hey, inner app... nothin'">
+		<inner-app (event1)="ctrl.onIncrement()" (event2)="ctrl.onIncrement()"
+		           [message1]="ctrl.message1" [(message2)]="ctrl.message2" message3="Hey, inner app... nothin'">
 		</inner-app>
 	`
 })

--- a/lib/classes/opaque-token.spec.ts
+++ b/lib/classes/opaque-token.spec.ts
@@ -16,7 +16,7 @@ describe("Opaque Token", () => {
 
     @Component({
       selector: 'player',
-      template: `{{player.lives}}`
+      template: `{{ctrl.lives}}`
     })
     @Inject(LIVES)
     class Player {

--- a/lib/classes/opaque-token.ts
+++ b/lib/classes/opaque-token.ts
@@ -9,7 +9,7 @@
 
  @Component({
    selector: 'player',
-   template: `Lives Left: {{player.lives}}`
+   template: `Lives Left: {{ctrl.lives}}`
  })
  @Inject(LIVES)
  class Player {

--- a/lib/decorators/component.spec.ts
+++ b/lib/decorators/component.spec.ts
@@ -149,11 +149,18 @@ describe('@Component', function(){
 			providerStore.get('name', lastEvent).should.eql('(first)');
 		});
 
-		it('should set component controllerAs metadata to camelCased selector', function(){
+		it('should set component controllerAs metadata to "ctrl" by default', function(){
 			@Component({ selector: 'foo', template: 'x' })
 			class MyComponentCtrl1{ }
 
-			@Component({ selector: 'foo-bar', template: 'x' })
+			componentStore.get('controllerAs', MyComponentCtrl1).should.eql('ctrl');
+		});
+
+		it('should set component controllerAs metadata to camelCased selector if value is $auto', function(){
+			@Component({ selector: 'foo', template: 'x', controllerAs: '$auto' })
+			class MyComponentCtrl1{ }
+
+			@Component({ selector: 'foo-bar', template: 'x', controllerAs: '$auto' })
 			class MyComponentCtrl2{ }
 
 			componentStore.get('controllerAs', MyComponentCtrl1).should.eql('foo');
@@ -298,8 +305,21 @@ describe('@Component', function(){
 			directive.name.should.eql('foo');
 		});
 
-		it('creates a directive with controllerAs created from selector', () => {
+		it('creates a directive with controllerAs set to "ctrl"', () => {
 			@Component({ selector: 'foo', template: 'x' })
+			class MyClass{ }
+
+			let fixture = quickFixture({
+				directives: [MyClass],
+				template: `<foo></foo>`
+			});
+
+			var directive = fixture.debugElement.getLocal('fooDirective')[0];
+			directive.controllerAs.should.eql('ctrl');
+		});
+
+		it('creates a directive with controllerAs set to "$auto"', () => {
+			@Component({ selector: 'foo', controllerAs: '$auto', template: 'x' })
 			class MyClass{ }
 
 			let fixture = quickFixture({
@@ -325,7 +345,7 @@ describe('@Component', function(){
 		});
 
 		it('creates a directive with multi-word selector that is provided', () => {
-			@Component({ selector: 'foo-bar', template: 'x' })
+			@Component({ selector: 'foo-bar', controllerAs: '$auto', template: 'x' })
 			class MyClass{ }
 
 			let fixture = quickFixture({
@@ -411,7 +431,7 @@ describe('@Component', function(){
 			});
 
 			it('adds each input as an allowed attribute on the element', () => {
-				@Component({ selector: 'foo', template: '{{foo.bar}} {{foo.baz}}', inputs: ['bar', 'baz'] })
+				@Component({ selector: 'foo', template: '{{ctrl.bar}} {{ctrl.baz}}', inputs: ['bar', 'baz'] })
 				class MyClass{ }
 
 				let fixture = quickFixture({
@@ -423,7 +443,7 @@ describe('@Component', function(){
 			});
 
 			it('disallows setting instance properties not marked as an input', () => {
-				@Component({ selector: 'foo', template: '{{foo.bar}} {{foo.baz}}', inputs: ['baz'] })
+				@Component({ selector: 'foo', template: '{{ctrl.bar}} {{ctrl.baz}}', inputs: ['baz'] })
 				class MyClass{
 					private bar = 'false';
 					private baz = 'false';
@@ -438,7 +458,7 @@ describe('@Component', function(){
 			});
 
 			it('allows setting inputs to default values', () => {
-				@Component({ selector: 'foo', template: '{{foo.foo}}', inputs: ['foo'] })
+				@Component({ selector: 'foo', template: '{{ctrl.foo}}', inputs: ['foo'] })
 				class MyClass{
 					private foo = 'bar';
 				}
@@ -455,7 +475,7 @@ describe('@Component', function(){
 				@Component({
 					selector: 'child',
 					inputs: ['foo'],
-					template: '{{child.foo}}'
+					template: '{{ctrl.foo}}'
 				})
 				class Child {}
 
@@ -489,7 +509,7 @@ describe('@Component', function(){
 				@Component({
 					selector: 'child',
 					inputs: ['foo'],
-					template: '{{child.foo}}'
+					template: '{{ctrl.foo}}'
 				})
 				class Child {}
 
@@ -497,8 +517,8 @@ describe('@Component', function(){
 					selector: 'parent',
 					directives: [Child],
 					template: `
-						<h1 class="greeting">{{parent.foo}} World!</h1>
-						<child [foo]="parent.foo"></child>
+						<h1 class="greeting">{{ctrl.foo}} World!</h1>
+						<child [foo]="ctrl.foo"></child>
 					`
 				})
 				class Parent { foo = "Hello"; }
@@ -533,7 +553,7 @@ describe('@Component', function(){
 				@Component({
 					selector: 'child',
 					inputs: ['foo'],
-					template: '{{child.foo}}'
+					template: '{{ctrl.foo}}'
 				})
 				class Child {}
 
@@ -541,8 +561,8 @@ describe('@Component', function(){
 					selector: 'parent',
 					directives: [Child],
 					template: `
-						<h1 class="greeting">{{parent.foo}} World!</h1>
-						<child [(foo)]="parent.foo"></child>
+						<h1 class="greeting">{{ctrl.foo}} World!</h1>
+						<child [(foo)]="ctrl.foo"></child>
 					`
 				})
 				class Parent {
@@ -579,7 +599,7 @@ describe('@Component', function(){
 				@Component({
 					selector: 'child',
 					inputs: ['foo'],
-					template: '{{child.foo}} {{child.baz}}'
+					template: '{{ctrl.foo}} {{ctrl.baz}}'
 				})
 				class Child {
 					private _foo;
@@ -622,7 +642,7 @@ describe('@Component', function(){
 				@Component({
 					selector: 'child',
 					inputs: ['foo'],
-					template: '{{child.foo}} {{child.baz}}'
+					template: '{{ctrl.foo}} {{ctrl.baz}}'
 				})
 				class Child {
 					private _foo;
@@ -639,8 +659,8 @@ describe('@Component', function(){
 					selector: 'parent',
 					directives: [Child],
 					template: `
-						<h1 class="greeting">{{parent.foo}} World!</h1>
-						<child [foo]="parent.foo"></child>
+						<h1 class="greeting">{{ctrl.foo}} World!</h1>
+						<child [foo]="ctrl.foo"></child>
 					`
 				})
 				class Parent { foo = "Hello"; }
@@ -675,7 +695,7 @@ describe('@Component', function(){
 				@Component({
 					selector: 'child',
 					inputs: ['foo'],
-					template: '{{child.foo}} {{child.baz}}'
+					template: '{{ctrl.foo}} {{ctrl.baz}}'
 				})
 				class Child {
 					private _foo;
@@ -692,8 +712,8 @@ describe('@Component', function(){
 					selector: 'parent',
 					directives: [Child],
 					template: `
-						<h1 class="greeting">{{parent.foo}} World!</h1>
-						<child [(foo)]="parent.foo"></child>
+						<h1 class="greeting">{{ctrl.foo}} World!</h1>
+						<child [(foo)]="ctrl.foo"></child>
 					`
 				})
 				class Parent {
@@ -731,7 +751,7 @@ describe('@Component', function(){
 					selector: 'child',
 					inputs: ['foo'],
 					outputs: ['fooChanged'],
-					template: '{{child.foo}}'
+					template: '{{ctrl.foo}}'
 				})
 				class Child {
 					private foo;
@@ -746,8 +766,8 @@ describe('@Component', function(){
 					selector: 'parent',
 					directives: [Child],
 					template: `
-						<h1 class="greeting">{{parent.foo}} World!</h1>
-						<child [foo]="parent.foo" (foo-changed)="parent.fooChanged($event)"></child>
+						<h1 class="greeting">{{ctrl.foo}} World!</h1>
+						<child [foo]="ctrl.foo" (foo-changed)="ctrl.fooChanged($event)"></child>
 					`
 				})
 				class Parent {
@@ -789,7 +809,7 @@ describe('@Component', function(){
 
 			describe('binding to scope or bindToController based on angular version', () => {
 				const quickBuildBindingTest = () => {
-					@Component({ selector: 'foo', template: '{{foo.bar}}', inputs: ['bar'] })
+					@Component({ selector: 'foo', template: '{{ctrl.bar}}', inputs: ['bar'] })
 					class MyClass{ }
 
 					let fixture = quickFixture({
@@ -858,7 +878,7 @@ describe('@Component', function(){
 
 				let fixture = quickFixture({
 					directives: [Foo],
-					template: `<foo ng-init="test.bar=false" (output)="test.bar=true"></foo>`
+					template: `<foo ng-init="ctrl.bar=false" (output)="ctrl.bar=true"></foo>`
 				});
 
 				fixture.debugElement.componentInstance.bar.should.be.false;
@@ -875,7 +895,7 @@ describe('@Component', function(){
 
 				let fixture = quickFixture({
 					directives: [Foo],
-					template: `<foo ng-init="test.bar=false" (output-change)="test.bar=true"></foo>`
+					template: `<foo ng-init="ctrl.bar=false" (output-change)="ctrl.bar=true"></foo>`
 				});
 
 				fixture.debugElement.componentInstance.bar.should.be.false;
@@ -892,7 +912,7 @@ describe('@Component', function(){
 
 				let fixture = quickFixture({
 					directives: [Foo],
-					template: `<foo ng-init="test.bar=false" (output)="test.bar=$event.detail"></foo>`
+					template: `<foo ng-init="ctrl.bar=false" (output)="ctrl.bar=$event.detail"></foo>`
 				});
 
 				fixture.debugElement.componentInstance.bar.should.be.false;
@@ -913,7 +933,7 @@ describe('@Component', function(){
 
 				let fixture = quickFixture({
 					directives: [Foo],
-					template: `<foo ng-init="test.bar=false" (output)="test.bar=true"></foo>`
+					template: `<foo ng-init="ctrl.bar=false" (output)="ctrl.bar=true"></foo>`
 				});
 
 				fixture.debugElement.componentInstance.bar.should.be.false;
@@ -932,7 +952,7 @@ describe('@Component', function(){
 
 				let fixture = quickFixture({
 					directives: [Foo],
-					template: `<foo ng-init="test.bar=false" (output-change)="test.bar=true"></foo>`
+					template: `<foo ng-init="ctrl.bar=false" (output-change)="ctrl.bar=true"></foo>`
 				});
 
 				fixture.debugElement.componentInstance.bar.should.be.false;
@@ -951,7 +971,7 @@ describe('@Component', function(){
 
 				let fixture = quickFixture({
 					directives: [Foo],
-					template: `<foo ng-init="test.bar=false" (output)="test.bar=$event.detail"></foo>`
+					template: `<foo ng-init="ctrl.bar=false" (output)="ctrl.bar=$event.detail"></foo>`
 				});
 
 				fixture.debugElement.componentInstance.bar.should.be.false;
@@ -972,7 +992,7 @@ describe('@Component', function(){
 
 				let fixture = quickFixture({
 					directives: [Foo],
-					template: `<foo ng-init="test.bar=false" (output)="test.bar=true"></foo>`
+					template: `<foo ng-init="ctrl.bar=false" (output)="ctrl.bar=true"></foo>`
 				});
 
 				fixture.debugElement.componentInstance.bar.should.be.false;
@@ -990,13 +1010,13 @@ describe('@Component', function(){
 				@Component({
 					selector: 'foo',
 					directives: [Bar],
-					template: `<bar ng-init="foo.bar=false" (bar-change)="foo.bar=true"></bar>`
+					template: `<bar ng-init="ctrl.bar=false" (bar-change)="ctrl.bar=true"></bar>`
 				})
 				class Foo { }
 
 				let fixture = quickFixture({
 					directives: [Foo],
-					template: `<foo ng-init="test.bar=false" (bar-change)="test.bar=true"></foo>`
+					template: `<foo ng-init="ctrl.bar=false" (bar-change)="ctrl.bar=true"></foo>`
 				});
 
 				let fixtureEl = fixture.debugElement;
@@ -1024,13 +1044,13 @@ describe('@Component', function(){
 				@Component({
 					selector: 'foo',
 					directives: [Bar],
-					template: `<bar ng-init="foo.bar=false" (bar-change)="foo.bar=true"></bar>`
+					template: `<bar ng-init="ctrl.bar=false" (bar-change)="ctrl.bar=true"></bar>`
 				})
 				class Foo { }
 
 				let fixture = quickFixture({
 					directives: [Foo],
-					template: `<foo ng-init="test.bar=false" (bar-change)="test.bar=true"></foo>`
+					template: `<foo ng-init="ctrl.bar=false" (bar-change)="ctrl.bar=true"></foo>`
 				});
 
 				let fixtureEl = fixture.debugElement;

--- a/lib/decorators/component.ts
+++ b/lib/decorators/component.ts
@@ -13,8 +13,8 @@
 // 	inputs: ['messageSubject: subject'],
 // 	bind: [Messenger]
 // 	template: `
-// 		<textarea ng-model="sendMessage.body"></textarea>
-// 		<button on-click="sendMessage.send()"></textarea>
+// 		<textarea ng-model="ctrl.body"></textarea>
+// 		<button on-click="ctrl.send()"></textarea>
 // 	`
 // })
 // @Inject(Messenger)
@@ -152,13 +152,16 @@ export function Component(
 
 
 		// Allow for renaming the controllerAs
-		if(controllerAs) {
-			componentStore.set('controllerAs', controllerAs, t);
-		}
-		else {
+		if(controllerAs === '$auto') {
 			// ControllerAs is the parsed selector. For example, `app` becomes `app` and
 			// `send-message` becomes `sendMessage`
 			componentStore.set('controllerAs', name, t);
+		} else if (controllerAs) {
+			// set to what was provided
+			componentStore.set('controllerAs', controllerAs, t);
+		} else {
+			// set to default of 'ctrl'
+			componentStore.set('controllerAs', 'ctrl', t);
 		}
 	
 		// Set a link function

--- a/lib/decorators/input-output.spec.ts
+++ b/lib/decorators/input-output.spec.ts
@@ -63,7 +63,7 @@ describe('@Input Decorator', function(){
 		});
 
 		it('adds each input as an allowed attribute on the element', () => {
-			@Component({ selector: 'foo', template: '{{foo.bar}} {{foo.baz}}' })
+			@Component({ selector: 'foo', template: '{{ctrl.bar}} {{ctrl.baz}}' })
 			class MyClass{
 				@Input() bar;
 				@Input() baz;
@@ -78,7 +78,7 @@ describe('@Input Decorator', function(){
 		});
 
 		it('disallows setting instance properties not marked as an input', () => {
-			@Component({ selector: 'foo', template: '{{foo.bar}} {{foo.baz}}' })
+			@Component({ selector: 'foo', template: '{{ctrl.bar}} {{ctrl.baz}}' })
 			class MyClass{
 				bar = 'false';
 				@Input() baz = 'false';
@@ -93,7 +93,7 @@ describe('@Input Decorator', function(){
 		});
 
 		it('allows setting inputs to default values', () => {
-			@Component({ selector: 'foo', template: '{{foo.foo}}' })
+			@Component({ selector: 'foo', template: '{{ctrl.foo}}' })
 			class MyClass{
 				@Input() foo = 'bar';
 			}
@@ -109,7 +109,7 @@ describe('@Input Decorator', function(){
 		it('one way binds a string to inputs with the regular syntax', () => {
 			@Component({
 				selector: 'child',
-				template: '{{child.foo}}'
+				template: '{{ctrl.foo}}'
 			})
 			class Child {
 				@Input() foo;
@@ -144,7 +144,7 @@ describe('@Input Decorator', function(){
 		it('one way binds to an expression to inputs with the [input] syntax', () => {
 			@Component({
 				selector: 'child',
-				template: '{{child.foo}}'
+				template: '{{ctrl.foo}}'
 			})
 			class Child {
 				@Input() foo;
@@ -154,8 +154,8 @@ describe('@Input Decorator', function(){
 				selector: 'parent',
 				directives: [Child],
 				template: `
-					<h1 class="greeting">{{parent.foo}} World!</h1>
-					<child [foo]="parent.foo"></child>
+					<h1 class="greeting">{{ctrl.foo}} World!</h1>
+					<child [foo]="ctrl.foo"></child>
 				`
 			})
 			class Parent { foo = "Hello"; }
@@ -189,7 +189,7 @@ describe('@Input Decorator', function(){
 		it('two way binds an expression to inputs with the [(input)] syntax', () => {
 			@Component({
 				selector: 'child',
-				template: '{{child.foo}}'
+				template: '{{ctrl.foo}}'
 			})
 			class Child {
 				@Input() foo;
@@ -199,8 +199,8 @@ describe('@Input Decorator', function(){
 				selector: 'parent',
 				directives: [Child],
 				template: `
-					<h1 class="greeting">{{parent.foo}} World!</h1>
-					<child [(foo)]="parent.foo"></child>
+					<h1 class="greeting">{{ctrl.foo}} World!</h1>
+					<child [(foo)]="ctrl.foo"></child>
 				`
 			})
 			class Parent {
@@ -236,7 +236,7 @@ describe('@Input Decorator', function(){
 		it('one way binds a string to inputs with getter/setter with the regular syntax', () => {
 			@Component({
 				selector: 'child',
-				template: '{{child.foo}} {{child.baz}}'
+				template: '{{ctrl.foo}} {{ctrl.baz}}'
 			})
 			class Child {
 				@Input() foo;
@@ -279,7 +279,7 @@ describe('@Input Decorator', function(){
 		it('one way binds to an expression to inputs with getter/setter with the [input] syntax', () => {
 			@Component({
 				selector: 'child',
-				template: '{{child.foo}} {{child.baz}}'
+				template: '{{ctrl.foo}} {{ctrl.baz}}'
 			})
 			class Child {
 				@Input() foo;
@@ -297,8 +297,8 @@ describe('@Input Decorator', function(){
 				selector: 'parent',
 				directives: [Child],
 				template: `
-					<h1 class="greeting">{{parent.foo}} World!</h1>
-					<child [foo]="parent.foo"></child>
+					<h1 class="greeting">{{ctrl.foo}} World!</h1>
+					<child [foo]="ctrl.foo"></child>
 				`
 			})
 			class Parent { foo = "Hello"; }
@@ -332,7 +332,7 @@ describe('@Input Decorator', function(){
 		it('two way binds an expression to inputs with getter/setter with the [(input)] syntax', () => {
 			@Component({
 				selector: 'child',
-				template: '{{child.foo}} {{child.baz}}'
+				template: '{{ctrl.foo}} {{ctrl.baz}}'
 			})
 			class Child {
 				@Input() foo;
@@ -350,8 +350,8 @@ describe('@Input Decorator', function(){
 				selector: 'parent',
 				directives: [Child],
 				template: `
-					<h1 class="greeting">{{parent.foo}} World!</h1>
-					<child [(foo)]="parent.foo"></child>
+					<h1 class="greeting">{{ctrl.foo}} World!</h1>
+					<child [(foo)]="ctrl.foo"></child>
 				`
 			})
 			class Parent {
@@ -388,7 +388,7 @@ describe('@Input Decorator', function(){
 			@Component({
 				selector: 'child',
 				outputs: ['fooChanged'],
-				template: '{{child.foo}}'
+				template: '{{ctrl.foo}}'
 			})
 			class Child {
 				@Input() foo;
@@ -403,8 +403,8 @@ describe('@Input Decorator', function(){
 				selector: 'parent',
 				directives: [Child],
 				template: `
-					<h1 class="greeting">{{parent.foo}} World!</h1>
-					<child [foo]="parent.foo" (foo-changed)="parent.fooChanged($event)"></child>
+					<h1 class="greeting">{{ctrl.foo}} World!</h1>
+					<child [foo]="ctrl.foo" (foo-changed)="ctrl.fooChanged($event)"></child>
 				`
 			})
 			class Parent {
@@ -446,7 +446,7 @@ describe('@Input Decorator', function(){
 
 		describe('binding to scope or bindToController based on angular version', () => {
 			const quickBuildBindingTest = () => {
-				@Component({ selector: 'foo', template: '{{foo.bar}}' })
+				@Component({ selector: 'foo', template: '{{ctrl.bar}}' })
 				class MyClass{
 					@Input() bar;
 				}
@@ -570,7 +570,7 @@ describe('@Output Decorator', function(){
 
 			let fixture = quickFixture({
 				directives: [Foo],
-				template: `<foo ng-init="test.bar=false" (output)="test.bar=true"></foo>`
+				template: `<foo ng-init="ctrl.bar=false" (output)="ctrl.bar=true"></foo>`
 			});
 
 			fixture.debugElement.componentInstance.bar.should.be.false;
@@ -589,7 +589,7 @@ describe('@Output Decorator', function(){
 
 			let fixture = quickFixture({
 				directives: [Foo],
-				template: `<foo ng-init="test.bar=false" (output-change)="test.bar=true"></foo>`
+				template: `<foo ng-init="ctrl.bar=false" (output-change)="ctrl.bar=true"></foo>`
 			});
 
 			fixture.debugElement.componentInstance.bar.should.be.false;
@@ -608,7 +608,7 @@ describe('@Output Decorator', function(){
 
 			let fixture = quickFixture({
 				directives: [Foo],
-				template: `<foo ng-init="test.bar=false" (output)="test.bar=$event.detail"></foo>`
+				template: `<foo ng-init="ctrl.bar=false" (output)="ctrl.bar=$event.detail"></foo>`
 			});
 
 			fixture.debugElement.componentInstance.bar.should.be.false;
@@ -629,7 +629,7 @@ describe('@Output Decorator', function(){
 
 			let fixture = quickFixture({
 				directives: [Foo],
-				template: `<foo ng-init="test.bar=false" (output)="test.bar=true"></foo>`
+				template: `<foo ng-init="ctrl.bar=false" (output)="ctrl.bar=true"></foo>`
 			});
 
 			fixture.debugElement.componentInstance.bar.should.be.false;
@@ -648,7 +648,7 @@ describe('@Output Decorator', function(){
 
 			let fixture = quickFixture({
 				directives: [Foo],
-				template: `<foo ng-init="test.bar=false" (output-change)="test.bar=true"></foo>`
+				template: `<foo ng-init="ctrl.bar=false" (output-change)="ctrl.bar=true"></foo>`
 			});
 
 			fixture.debugElement.componentInstance.bar.should.be.false;
@@ -667,7 +667,7 @@ describe('@Output Decorator', function(){
 
 			let fixture = quickFixture({
 				directives: [Foo],
-				template: `<foo ng-init="test.bar=false" (output)="test.bar=$event.detail"></foo>`
+				template: `<foo ng-init="ctrl.bar=false" (output)="ctrl.bar=$event.detail"></foo>`
 			});
 
 			fixture.debugElement.componentInstance.bar.should.be.false;
@@ -688,7 +688,7 @@ describe('@Output Decorator', function(){
 
 			let fixture = quickFixture({
 				directives: [Foo],
-				template: `<foo ng-init="test.bar=false" (output)="test.bar=true"></foo>`
+				template: `<foo ng-init="ctrl.bar=false" (output)="ctrl.bar=true"></foo>`
 			});
 
 			fixture.debugElement.componentInstance.bar.should.be.false;
@@ -708,13 +708,13 @@ describe('@Output Decorator', function(){
 			@Component({
 				selector: 'foo',
 				directives: [Bar],
-				template: `<bar ng-init="foo.bar=false" (bar-change)="foo.bar=true"></bar>`
+				template: `<bar ng-init="ctrl.bar=false" (bar-change)="ctrl.bar=true"></bar>`
 			})
 			class Foo { }
 
 			let fixture = quickFixture({
 				directives: [Foo],
-				template: `<foo ng-init="test.bar=false" (bar-change)="test.bar=true"></foo>`
+				template: `<foo ng-init="ctrl.bar=false" (bar-change)="ctrl.bar=true"></foo>`
 			});
 
 			let fixtureEl = fixture.debugElement;
@@ -742,13 +742,13 @@ describe('@Output Decorator', function(){
 			@Component({
 				selector: 'foo',
 				directives: [Bar],
-				template: `<bar ng-init="foo.bar=false" (bar-change)="foo.bar=true"></bar>`
+				template: `<bar ng-init="ctrl.bar=false" (bar-change)="ctrl.bar=true"></bar>`
 			})
 			class Foo { }
 
 			let fixture = quickFixture({
 				directives: [Foo],
-				template: `<foo ng-init="test.bar=false" (bar-change)="test.bar=true"></foo>`
+				template: `<foo ng-init="ctrl.bar=false" (bar-change)="ctrl.bar=true"></foo>`
 			});
 
 			let fixtureEl = fixture.debugElement;

--- a/lib/events/events.spec.ts
+++ b/lib/events/events.spec.ts
@@ -37,7 +37,7 @@ describe('Auto-generated Event Directives', function(){
     xit('bubbles the events', () => {
       let fixture = quickFixture({
         template: `
-        <div ng-init="test.clicked=false" (click)="test.clicked=true">
+        <div ng-init="ctrl.clicked=false" (click)="ctrl.clicked=true">
           <button>Click Me</button>
         </div>
         `

--- a/lib/testing/test-component-builder.spec.ts
+++ b/lib/testing/test-component-builder.spec.ts
@@ -35,7 +35,7 @@ describe('Test Utils', () => {
       selector: 'some-component',
       inputs: ['foo', 'baz:bar'],
       bindings: [SomeService],
-      template: `{{someComponent.foo}} {{someComponent.baz}} {{someComponent.quux()}} {{someComponent.local}}`
+      template: `{{ctrl.foo}} {{ctrl.baz}} {{ctrl.quux()}} {{ctrl.local}}`
     })
     @Inject(SomeService, SomeOtherService, '$http', '$timeout')
     class _SomeComponent {
@@ -50,7 +50,7 @@ describe('Test Utils', () => {
 
     @Component({
       selector: 'test',
-      template: `<some-component foo="Hello" [bar]="test.bar"></some-component>`,
+      template: `<some-component foo="Hello" [bar]="ctrl.bar"></some-component>`,
       directives: [SomeComponent]
     })
     class _TestComponent {

--- a/lib/util/jqlite-extensions.ts
+++ b/lib/util/jqlite-extensions.ts
@@ -39,8 +39,7 @@ export interface INgForwardJQuery extends IAugmentedJQuery {
       get() {
         if (this._componentInstance) return this._componentInstance;
         let isolateScope = this.isolateScope();
-        let name = dashToCamel(this[0].tagName.toLowerCase());
-        this._componentInstance = isolateScope && isolateScope[name] || null;
+        this._componentInstance = isolateScope && isolateScope['ctrl'] || null;
         return this._componentInstance;
       }
     },


### PR DESCRIPTION
feat(controllerAs): Set default controllerAs value to 'ctrl'.

For easier migration to Angular 2 later via simple find/replace. To keep the older behavior set controllerAs to '$auto'.

BREAKING CHANGE:

Before:
```js
@Component({ selector: 'app', template: '{{app.foo}}' })
```

After:
```js
@Component({ selector: 'app', template: '{{ctrl.foo}}' })

// or

@Component({ selector: 'app', controllerAs: '$auto', template: '{{app.foo}}' })
```

close #6 