### PR TITLE
Inject parent components into child components

### DIFF
--- a/API.md
+++ b/API.md
@@ -62,7 +62,7 @@ Example:
 ```js
 import { bundle, Component } from 'ng-forward';
 
-@Component({ selector: 'app', template: 'Hello World!', 
+@Component({ selector: 'app', template: 'Hello World!',
     providers: [...otherProvidersToIncludeInTheBundle],
     directives: [...otherDirectivesToIncludeInTheBundle]
 })
@@ -168,14 +168,14 @@ Example:
 ```js
 import { Component } from 'ng-forward';
 
-@Component({ 
-    selector: 'app', 
+@Component({
+    selector: 'app',
     template: `Hello {{ctrl.place}}!`,
     providers: [...providers],
     directives: [...directives]
     pipes: [...pipes]
 })
-class App { 
+class App {
     constructor() {
         this.place = "World";
     }
@@ -203,8 +203,8 @@ Inputs and Outputs are the public API of a component. There are two ways to spec
 If you had a component `MenuDropdown` like so:
 
 ```js
-@Component({ 
-    selector: 'menu-dropdown', 
+@Component({
+    selector: 'menu-dropdown',
     template: `
     <label>{{ctrl.name}}</label>
     <a ng-repeat="option in ctrl.options" ng-href="{{option.action}}">{{option.name}}</a>
@@ -233,7 +233,7 @@ Then I could use that component in another component's template like so, passing
 class MainMenu {}
 ```
 
-Every input can be bound in three different ways, just like Angular 2: 
+Every input can be bound in three different ways, just like Angular 2:
 
 - String-based `foo="some string"`. Will pass the raw string into the input.
 - One-way binding `[foo]="someObj.property"`. Will one-way bind the expression to the input. The input can be changed locally but if the expression ever changes it will overwrite the input with the latest value.
@@ -251,7 +251,7 @@ import { Component, EventEmitter } from 'ng-forward';
 class MenuDropdown {
     // Initialize your output as an EventEmitter and now you can trigger with .next()
     optionSelect = new EventEmitter();
-    
+
     triggerEventViaEventEmitter() {
         this.optionSelect.next(selectedOption)
     }
@@ -270,7 +270,7 @@ class MenuDropdown {
         // Need a reference to the host element for DOM event triggering
         this.$element = $element;
     }
-    
+
     triggerEventViaDOM() {
         this.$element.triggerHandler('optionSelect');
         // or for bubbling of custom events...
@@ -280,10 +280,10 @@ class MenuDropdown {
 ```
 
 ###### Transclusion
- 
-Transclusion is always enabled. Just add `<ng-content></ng-content>` (converted to ng-transclude) or `<ng-transclude></ng-tranclude>` to mark your transclusion point. No real reason to set this to false. We always set it to `true`. You can tranclude by default. 
 
-###### Behind the Scenes 
+Transclusion is always enabled. Just add `<ng-content></ng-content>` (converted to ng-transclude) or `<ng-transclude></ng-tranclude>` to mark your transclusion point. No real reason to set this to false. We always set it to `true`. You can tranclude by default.
+
+###### Behind the Scenes
 
 At [bootstrap](https://github.com/ngUpgraders/ng-forward/blob/master/API.md#bootstrap) time, a call to `angular.directive` is made. Angular 1 directive properties are set as follows:
 
@@ -308,12 +308,12 @@ Example:
 ```js
 import { Directive } from 'ng-forward';
 
-@Directive({ 
-    selector: '[foo-class]', 
+@Directive({
+    selector: '[foo-class]',
     providers: [...providers],
 })
 @Inject('$element')
-class FooClass { 
+class FooClass {
     constructor($element) {
         $element.addClass('foo');
     }
@@ -325,7 +325,7 @@ class FooClass {
 - **`selector`**  **string**  The component's selector. It must be a css attribute selector, for example `'[my-thing]'` is **valid**, but `'my-component'` or `'.my-class'` are **invalid**.
 - **`providers`**  **[Array&lt;IProvidable&gt;]**  Any providers that this component or any of it's children depends on.
 
-###### Behind the Scenes 
+###### Behind the Scenes
 
 At [bootstrap](https://github.com/ngUpgraders/ng-forward/blob/master/API.md#bootstrap) time, a call to `angular.directive` is made. Angular 1 directive properties are set as follows:
 
@@ -446,7 +446,7 @@ class MyOtherService {
 ```
 
 ###### Behind the Scenes
- 
+
 At bootstrap time, a call to `module.service` is made. The service name is auto-generated as you should not need to access manually. If you must access it, use the [getInjectableName()](https://github.com/ngUpgraders/ng-forward/blob/master/API.md#getinjectablename) utility method.
 
 ## @Inject
@@ -459,10 +459,13 @@ import { Component, Inject } from 'ng-forward';
 import { MyService } from './my-service.js';
 
 @Component()
-@Inject('$q', '$element', MyService)
-class MyOtherService {
-    constructor($q, $element, myService) { }
-    
+class MyParentComponent {}
+
+@Component()
+@Inject('$q', '$element', MyService, MyParentComponent)
+class MyChildComponent {
+    constructor($q, $element, myService, myParent) { }
+
     // also works on static methods
     @Inject('$q', '$element', MyService)
     static foo($q, $element, myService) {}
@@ -473,11 +476,11 @@ class MyOtherService {
 
 - **`injectables`**  **string | class**  One or more injectables. Can be of type **string** or **class**.
     - If **string**, then it's considered a core angular service such as $q or $http. It could also be a special 'local', for example component's can inject `$element`, `$attrs` or `$scope`.
-    - If **class**, then it's considered to be an annotated class that is injectable, for example via the [@Injectable](https://github.com/ngUpgraders/ng-forward/blob/master/API.md#injectable) decorator.
+    - If **class**, then it's considered to be an annotated class that is injectable, for example via the [@Injectable](https://github.com/ngUpgraders/ng-forward/blob/master/API.md#injectable) decorator or a parent component class. Parent components can only be injected into the constructor of another component. Also currently this only works when the child is transcluded into the parent.
 
 ###### Behind the Scenes
 
-The injectables are added to the `$inject` property of the class constructor function.
+The injectables are added to the `$inject` property of the class constructor function. Parent components will be injected as locals.
 
 ## provide
 
@@ -693,7 +696,7 @@ class Parent {}
 
 - **`resolveName`**  **[string]**  If provided, you will use this name when requesting the resolve from the injector.
 
-## DecoratedModule 
+## DecoratedModule
 
 A wrapper around the angular 1 module. This is mostly private and you shouldn't need to use it unless you are creating a plugin.
 

--- a/lib/decorators/component.ts
+++ b/lib/decorators/component.ts
@@ -87,7 +87,7 @@ export function Component(
 			outputs = [],
 			pipes = [],
 			directives = []
-		} : 
+		} :
 		{
 			selector: string,
 			controllerAs?: string,
@@ -105,34 +105,34 @@ export function Component(
 		if( !selector ) {
 			throw new Error(`Component Decorator Error in "${t.name}": Component selector must be provided`);
 		}
-	
+
 		// Grab the provider name and selector type by parsing the selector
 		let {name, type: restrict} = parseSelector(selector);
-	
+
 		// Setup provider information using the parsed selector
 		providerStore.set('name', name, t);
 		providerStore.set('type', TYPE, t);
-	
+
 		// The appWriter needs the raw selector. This lets it bootstrap the root component
 		bundleStore.set('selector', selector, t);
-	
+
 		// Grab the providers from the config object, parse them, and write the metadata
 		// to the target.
 		Providers(...providers)(t, `while analyzing Component '${t.name}' providers`);
-	
+
 		// Restrict type must be 'element'
 		componentStore.set('restrict', restrict, t);
-	
+
 		// Components should always create an isolate scope
 		componentStore.set('scope', {}, t);
-		
+
 		// Since components must have a template, set transclude to true
 		componentStore.set('transclude', true, t);
-	
+
 		// Inputs should always be bound to the controller instance, not
 		// to the scope
 		componentStore.set('bindToController', true, t);
-	
+
 		// Must perform some basic shape checking on the config object
 		[
 			['inputs', inputs],
@@ -163,17 +163,17 @@ export function Component(
 			// set to default of 'ctrl'
 			componentStore.set('controllerAs', 'ctrl', t);
 		}
-	
+
 		// Set a link function
 		if(t.link) {
 			componentStore.set('link', t.link, t);
 		}
-	
+
 		// Set a compile function
 		if(t.compile){
 			componentStore.set('compile', t.compile, t);
 		}
-	
+
 		View({
 			selector,
 			template,
@@ -210,7 +210,7 @@ export function View(
 		else {
 			throw new Error(`@Component config must include either a template or a template url for component with selector ${selector} on ${t.name}`);
 		}
-	
+
 		Providers(...directives)(t, `while analyzing Component '${t.name}' directives`);
 		Providers(...pipes)(t, `while analyzing Component '${t.name}' pipes`);
 	}
@@ -240,6 +240,7 @@ Module.addProvider(TYPE, (target: any, name: string, injects: string[], ngModule
 	controller.$inject = ['$scope', '$element', '$attrs', '$transclude', '$injector'];
 	function controller($scope: any, $element: any, $attrs: any, $transclude: any, $injector: any): any{
 		let locals = { $scope, $element, $attrs, $transclude };
+
 		return directiveControllerFactory(this, injects, target, ddo, $injector, locals);
 	}
 	ddo.controller = controller;


### PR DESCRIPTION
This implements #98, but it only works for transcluded children. Direct children can't retrieve their parents this way because you get a circular dependency between the the parent (which needs the child for its `directives` option) and the child (which needs its parent for the `@Inject` decorator).